### PR TITLE
Remove the shib_authorizer flag on the config, update readme

### DIFF
--- a/README
+++ b/README
@@ -5,14 +5,13 @@ This module allows authorization based on the result of a subrequest to Shibbole
 Once a subrequest returns 2xx status - access is allowed; on 401 or 403 - 
 access is disabled with an appropriate status.  
 
-For 401 statuses, the WWW-Authenticate header from the subrequest response 
-will be passed to client.
-
-All other subrequest response statuses are considered to be an error, unless
-the `shib_authorizer=on` flag is supplied, in which case the module will
-return the subrequest's response status and headers. This mostly follows
-the FastCGI Authorizer specification, with the exception of the processing
-of the request and response bodies. Further information follows below.
+For 40x statuses, the WWW-Authenticate header from the subrequest response 
+will be passed to client.  All other subrequest response statuses (such as 
+3xx redirects) are passed back to the client, including status and headers. 
+This mostly conforms to the FastCGI Authorizer specification, with the exception 
+of the processing of the sub-request and sub-response bodies due to limitations
+in Nginx. As the Shibboleth FastCGI authorizer does not consider the contents of
+a request body or use response bodies, this is not an issue.
 
 The module works at access phase and therefore may be combined nicely with other
 access modules (access, auth_basic) via satisfy directive.
@@ -21,33 +20,31 @@ access modules (access, auth_basic) via satisfy directive.
 Configuration directives
 ========================
 
-    shib_request <uri>|off [flags]
+    shib_request <uri>|off
 
         Context: http, server, location
         Default: off
 
-        Switches Shibboleth auth request module on and sets uri which will be 
-        asked for authorization.
+        Switches the Shibboleth auth request module on and sets uri which will be 
+        asked for authorization.  The configured uri should refer to a Nginx
+        location block that points to your Shibboleth FastCGI authorizer.
 
-        Flags may be configured to modify the behaviour of the module as
-        follows:
-        
-         * shib_authorizer=on - Configures the auth request module to explicitly
-           return the status, headers, and content of the response resulting
-           from the sub-request to the configured uri.
- 
-           This option allows a uri to conform to the FastCGI Authorizer
-           specification; see http://www.fastcgi.com/drupal/node/22#S6.3.
-           The one (potentially significant) caveat is that due to the way
-           Nginx operates at present with regards to subrequests (what
-           an Authorizer effectively requires), the request body will *not* be
-           forwarded to the authorizer, and similarly, the response body from
-           the authorizer will *not* be returned to the client. 
+        The HTTP status and headers of the response resulting
+        from the sub-request to the configured uri will be returned to the user,
+        in accordance with the FastCGI Authorizer
+        specification; see http://www.fastcgi.com/drupal/node/22#S6.3.
+        The one (potentially significant) caveat is that due to the way
+        Nginx operates at present with regards to subrequests (what
+        an Authorizer effectively requires), the request body will *not* be
+        forwarded to the authorizer, and similarly, the response body from
+        the authorizer will *not* be returned to the client. 
 
-           Configured URIs are not restricted to using a FastCGI backend
-           to generate a response, however.  This may be useful during
-           testing or otherwise, as you can use Nginx's built in ``return``
-           and ``rewrite`` directives to produce a suitable response.
+        Configured URIs are not restricted to using a FastCGI backend
+        to generate a response, however.  This may be useful during
+        testing or otherwise, as you can use Nginx's built in ``return``
+        and ``rewrite`` directives to produce a suitable response.
+        Additionally, this module may be used with *any* FastCGI
+        authorizer, although operation may be affected by the above caveat.
 
     shib_request_set <variable> <value>
 
@@ -78,7 +75,7 @@ Usage
         # by the FastCGI authorizer so we must prevent spoofing.
         more_clear_input_headers 'displayName' 'mail' 'persistent-id';
         
-        shib_request /shibauthorizer shib_authorizer=on;
+        shib_request /shibauthorizer;
         proxy_pass http://localhost:8080;
     }
 

--- a/README.rst
+++ b/README.rst
@@ -1,24 +1,32 @@
 Shibboleth auth request module for nginx
 ========================================
 
-This module allows authorization based on the result of a subrequest to Shibboleth.
-Once a subrequest returns 2xx status - access is allowed; on 401 or 403 - 
-access is disabled with an appropriate status.  
+This module allows authorization based on the result of a subrequest to
+Shibboleth.  Once a subrequest returns 2xx status - access is allowed; on 401
+or 403 - access is disabled with an appropriate status.
 
-For 40x statuses, the WWW-Authenticate header from the subrequest response 
-will be passed to client.  All other subrequest response statuses (such as 
-3xx redirects) are passed back to the client, including status and headers. 
-This mostly conforms to the FastCGI Authorizer specification, with the exception 
-of the processing of the sub-request and sub-response bodies due to limitations
-in Nginx. As the Shibboleth FastCGI authorizer does not consider the contents of
-a request body or use response bodies, this is not an issue.
+For 40x statuses, the WWW-Authenticate header from the subrequest response
+will be passed to client.  All other subrequest response statuses (such as 3xx
+redirects) are passed back to the client, including status and headers.  This
+mostly conforms to the FastCGI Authorizer specification, with the exception of
+the processing of the sub-request and sub-response bodies due to limitations
+in Nginx. As the Shibboleth FastCGI authorizer does not consider the contents
+of a request body or use response bodies, this is not an issue.
 
-The module works at access phase and therefore may be combined nicely with other
-access modules (access, auth_basic) via satisfy directive.
+The module works at access phase and therefore may be combined nicely with
+other access modules (access, auth_basic) via satisfy directive.
 
 
 Configuration directives
 ========================
+
+.. warning::
+
+   The ``shib_request`` directive no longer requires the ``shib_authorizer``
+   flag.  This must be removed for Nginx to start. No other changes are
+   required.
+
+::
 
     shib_request <uri>|off
 
@@ -58,6 +66,8 @@ Configuration directives
 Usage
 =====
 
+::
+
     # FastCGI authorizer for Shibboleth Auth Request module
     location = /shibauthorizer {
         internal;
@@ -65,16 +75,15 @@ Usage
         fastcgi_pass unix:/opt/shibboleth/shibauthorizer.sock;
     }
 
-
     # A secured location. All incoming requests query the Shibboleth FastCGI authorizer.
     # Watch out for performance issues and spoofing.
     location /secure {
         more_clear_input_headers 'Variable-*' 'Shib-*' 'Remote-User' 'REMOTE_USER' 'Auth-Type' 'AUTH_TYPE';
-        
+
         # Add your attributes here. They get introduced as headers
         # by the FastCGI authorizer so we must prevent spoofing.
         more_clear_input_headers 'displayName' 'mail' 'persistent-id';
-        
+
         shib_request /shibauthorizer;
         proxy_pass http://localhost:8080;
     }
@@ -83,8 +92,11 @@ Usage
 Misc
 ====
 
-To compile nginx with this module, use "--add-module <path>" option
-to nginx configure.
+To compile nginx with this module, use the::
+
+    --add-module <path>
+
+option when you ``configure`` nginx.
 
 For further information on why this is a dedicated module, see
 http://forum.nginx.org/read.php?2,238523,238523#msg-238523


### PR DESCRIPTION
Now this is a separate module, the extra configuration flag is unnecessary, since we know we always want to operate in authorizer mode.  Superfluous code from the original `auth_request` module has been removed.

Existing configuration with `shib_authorizer=yes` must be updated to remove this flag or Nginx will error on starting.

This updates the readme as well to reflect this change.
