### PR TITLE
Fix compatibility with nginx 1.23.0+

### DIFF
--- a/ngx_http_shibboleth_module.c
+++ b/ngx_http_shibboleth_module.c
@@ -763,6 +763,9 @@ ngx_http_set_header_helper(ngx_http_request_t *r, ngx_http_shib_request_header_v
 
     h->key = hv->key;
     h->value = *value;
+#if defined(nginx_version) && nginx_version >= 1023000
+    h->next = NULL;
+#endif
 
     h->lowcase_key = ngx_pnalloc(r->pool, h->key.len);
     if (h->lowcase_key == NULL) {

--- a/ngx_http_shibboleth_module.c
+++ b/ngx_http_shibboleth_module.c
@@ -9,6 +9,9 @@
  * Contains elements adapted from ngx_lua:
  *   Copyright (C) 2009-2015, by Xiaozhe Wang (chaoslawful) chaoslawful@gmail.com.
  *   Copyright (C) 2009-2015, by Yichun "agentzh" Zhang (章亦春) agentzh@gmail.com, CloudFlare Inc.
+ * Contains elements adapted from ngx_headers_more:
+ *   Copyright (c) 2009-2017, Yichun "agentzh" Zhang (章亦春) agentzh@gmail.com, OpenResty Inc.
+ *   Copyright (c) 2010-2013, Bernd Dorn.
  *
  *  Distributed under 2-clause BSD license, see LICENSE file.
  */
@@ -840,6 +843,46 @@ static ngx_int_t
 ngx_http_set_builtin_multi_header(ngx_http_request_t *r,
     ngx_http_shib_request_header_val_t *hv, ngx_str_t *value)
 {
+#if defined(nginx_version) && nginx_version >= 1023000
+    ngx_table_elt_t  **headers, *h, *ho, **ph;
+
+    headers = (ngx_table_elt_t **) ((char *) &r->headers_out + hv->offset);
+
+    if (*headers) {
+        for (h = (*headers)->next; h; h = h->next) {
+            h->hash = 0;
+            h->value.len = 0;
+        }
+
+        h = *headers;
+
+        h->value = *value;
+
+        if (value->len == 0) {
+            h->hash = 0;
+
+        } else {
+            h->hash = hv->hash;
+        }
+
+        return NGX_OK;
+    }
+
+    for (ph = headers; *ph; ph = &(*ph)->next) { /* void */ }
+
+    ho = ngx_list_push(&r->headers_out.headers);
+    if (ho == NULL) {
+        return NGX_ERROR;
+    }
+
+    ho->value = *value;
+    ho->hash = hv->hash;
+    ngx_str_set(&ho->key, "Cache-Control");
+    ho->next = NULL;
+    *ph = ho;
+
+    return NGX_OK;
+#else
     ngx_array_t      *pa;
     ngx_table_elt_t  *ho, **ph;
     ngx_uint_t        i;
@@ -898,6 +941,7 @@ ngx_http_set_builtin_multi_header(ngx_http_request_t *r,
     *ph = ho;
 
     return NGX_OK;
+#endif
 }
 
 


### PR DESCRIPTION
This pull requests includes the same fixes I mentioned in issue #48 but with proper references to their origin in openresty/headers-more-nginx-module where they were created and contributed by other people.

Besides me a few other users of ngx_http_shibboleth independently verified that these changes are sufficient to fix the core dumps apparently caused by the changes made in nginx 1.23.0 concerning the internal representation of headers.